### PR TITLE
feat: 複数ファイルを同時にステージングする機能に対応

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -26,33 +26,35 @@ const getEntryFromFile = async (addingFilePath: string): Promise<Entry> => {
   };
 };
 
-export const add = async (addingFilePath: string): Promise<void> => {
+export const add = async (addingFiles: Array<string>): Promise<void> => {
   const indexPath = getGitPath(process.cwd()) + "index";
   const index = new Index();
   await index.build(indexPath);
-  const isFileExists = await doesFileExist(addingFilePath);
-  const existingEntryIndex = index.entries.findIndex(
-    (entry) => entry.fileName === addingFilePath,
-  );
-  if (!isFileExists && existingEntryIndex === -1) {
-    return;
-  }
-  if (isFileExists && existingEntryIndex !== -1) {
-    // 更新
-    const newEntry = await getEntryFromFile(addingFilePath);
-    index.entries[existingEntryIndex] = newEntry;
-  }
-  if (isFileExists && existingEntryIndex === -1) {
-    // 追加
-    const newEntry = await getEntryFromFile(addingFilePath);
-    index.entries.push(newEntry);
-  }
-  if (!isFileExists && existingEntryIndex !== -1) {
-    // 削除
-    index.entries = [
-      ...index.entries.slice(0, existingEntryIndex),
-      ...index.entries.slice(existingEntryIndex + 1),
-    ];
+  for (const addingFilePath of addingFiles) {
+    const isFileExists = await doesFileExist(addingFilePath);
+    const existingEntryIndex = index.entries.findIndex(
+      (entry) => entry.fileName === addingFilePath,
+    );
+    if (!isFileExists && existingEntryIndex === -1) {
+      return;
+    }
+    if (isFileExists && existingEntryIndex !== -1) {
+      // 更新
+      const newEntry = await getEntryFromFile(addingFilePath);
+      index.entries[existingEntryIndex] = newEntry;
+    }
+    if (isFileExists && existingEntryIndex === -1) {
+      // 追加
+      const newEntry = await getEntryFromFile(addingFilePath);
+      index.entries.push(newEntry);
+    }
+    if (!isFileExists && existingEntryIndex !== -1) {
+      // 削除
+      index.entries = [
+        ...index.entries.slice(0, existingEntryIndex),
+        ...index.entries.slice(existingEntryIndex + 1),
+      ];
+    }
   }
   await index.dump(indexPath);
   return;

--- a/src/mygit.ts
+++ b/src/mygit.ts
@@ -16,7 +16,7 @@ export const mygit = async (argv: Array<string>): Promise<void> => {
         console.error("Please specify the file path to add");
         return;
       }
-      await add(argv[3]);
+      await add(argv.slice(3));
       break;
     case "commit":
       if (!argv[3]) {


### PR DESCRIPTION
## Objective and links

<!--
この変更が必要になった背景や変更の目的を書いてください。
Asana のリンクや、もしあれば Google docs　や Slack threads など関連するリンクを貼ってください。
-->
本家gitでは実行時の引数として複数ファイルを指定することが可能で、その仕様に近づけるため。
asana: https://app.asana.com/0/1208202313452411/1208289490341650/f

## What was changed
第3引数以降に指定された文字列は全てファイルであると考えて、そのファイルをステージングするように変更しました。

## QA

既存のgitレポジトリで、複数ファイルを指定してみてadd, modify, deleteの3つについて正しく機能することを確認しました。`git status`を実行し、変更がステージングされたことを確認しました。

